### PR TITLE
Fix scraper coordinate parsing

### DIFF
--- a/Domasna 3 i 4/Hotel Management/src/main/java/com/dians/hotelmanagement/repository/ScraperRepository.java
+++ b/Domasna 3 i 4/Hotel Management/src/main/java/com/dians/hotelmanagement/repository/ScraperRepository.java
@@ -77,9 +77,9 @@ public class ScraperRepository {
                                             .flatMap(t -> t.dataNodes().stream())
                                             .filter(t -> t.getWholeData().contains("position"))
                                             .findFirst();
-                                    int indexCoordinates = rawHtml.toString().indexOf("LatLng");
-                                    String[] coordinates = rawHtml.toString()
-                                            .substring(indexCoordinates + 7, indexCoordinates + 27)
+                                    String data = rawHtml.map(DataNode::getWholeData).orElse("");
+                                    int indexCoordinates = data.indexOf("LatLng");
+                                    String[] coordinates = data.substring(indexCoordinates + 7, indexCoordinates + 27)
                                             .split(",");
                                     double longitude = Double.parseDouble(coordinates[0]);
                                     double latitude = Double.parseDouble(coordinates[1]);


### PR DESCRIPTION
## Summary
- fix hotel scraper to properly parse coordinate data from JS script blocks

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686594b54dcc832cac5ecb546c47d073