### PR TITLE
Improve error handling and hotel sorting

### DIFF
--- a/Domasna 3 i 4/Hotel Management/src/main/java/com/dians/hotelmanagement/repository/ScraperRepository.java
+++ b/Domasna 3 i 4/Hotel Management/src/main/java/com/dians/hotelmanagement/repository/ScraperRepository.java
@@ -77,9 +77,9 @@ public class ScraperRepository {
                                             .flatMap(t -> t.dataNodes().stream())
                                             .filter(t -> t.getWholeData().contains("position"))
                                             .findFirst();
-                                    int indexCoordinates = rawHtml.toString().indexOf("LatLng");
-                                    String[] coordinates = rawHtml.toString()
-                                            .substring(indexCoordinates + 7, indexCoordinates + 27)
+                                    String data = rawHtml.map(DataNode::getWholeData).orElse("");
+                                    int indexCoordinates = data.indexOf("LatLng");
+                                    String[] coordinates = data.substring(indexCoordinates + 7, indexCoordinates + 27)
                                             .split(",");
                                     double longitude = Double.parseDouble(coordinates[0]);
                                     double latitude = Double.parseDouble(coordinates[1]);

--- a/Domasna 3 i 4/Hotel Management/src/main/java/com/dians/hotelmanagement/service/implementation/HotelServiceImplementation.java
+++ b/Domasna 3 i 4/Hotel Management/src/main/java/com/dians/hotelmanagement/service/implementation/HotelServiceImplementation.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.collect;
-
 @Service
 public class HotelServiceImplementation implements HotelService {
     private final HotelRepository hotelRepository;
@@ -42,12 +40,12 @@ public class HotelServiceImplementation implements HotelService {
     @Override
     public List<Hotel> findMostPopularHotels() {
         return this.hotelRepository.findAll().stream()
-                .sorted((k, v) -> v.getFeedbacks().stream()
-                        .map(Feedback::getStars)
-                        .reduce(0, Integer::sum)
-                        .compareTo(k.getFeedbacks().stream()
-                                .map(Feedback::getStars)
-                                .reduce(0, Integer::sum)))
+                .sorted(Comparator.comparingInt(
+                        h -> h.getFeedbacks() == null ? 0 :
+                                h.getFeedbacks().stream()
+                                        .mapToInt(Feedback::getStars)
+                                        .sum())
+                        .reversed())
                 .limit(3)
                 .collect(Collectors.toList());
     }

--- a/Domasna 3 i 4/Hotel Management/src/main/java/com/dians/hotelmanagement/web/controller/LoginController.java
+++ b/Domasna 3 i 4/Hotel Management/src/main/java/com/dians/hotelmanagement/web/controller/LoginController.java
@@ -25,7 +25,7 @@ public class LoginController {
     @GetMapping
     public String getLoginPage(@RequestParam(required = false) String error, Model model) {
         model.addAttribute("bodyContent", "login");
-        model.addAttribute("hasError", true);
+        model.addAttribute("hasError", error != null);
         model.addAttribute("error", error);
         return "master-template";
     }

--- a/Domasna 3 i 4/Hotel Management/src/main/java/com/dians/hotelmanagement/web/controller/RegisterController.java
+++ b/Domasna 3 i 4/Hotel Management/src/main/java/com/dians/hotelmanagement/web/controller/RegisterController.java
@@ -24,7 +24,7 @@ public class RegisterController {
     @GetMapping
     public String getRegisterPage(@RequestParam(required = false) String error, Model model) {
         model.addAttribute("bodyContent", "register");
-        model.addAttribute("hasError", true);
+        model.addAttribute("hasError", error != null);
         model.addAttribute("error", error);
         return "master-template";
     }


### PR DESCRIPTION
## Summary
- fix login and registration pages to only show error state when needed
- refine most-popular hotel calculation and drop unused import

## Testing
- `./mvnw -q test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686594b54dcc832cac5ecb546c47d073